### PR TITLE
Fix duplication issue with migrate command, add permission node to migrate command

### DIFF
--- a/common/src/main/java/com/selfdot/cobblemonmegas/common/command/CommandTree.java
+++ b/common/src/main/java/com/selfdot/cobblemonmegas/common/command/CommandTree.java
@@ -104,7 +104,9 @@ public class CommandTree {
         );
         dispatcher.register(LiteralArgumentBuilder.<ServerCommandSource>
                         literal("migratestone")
-                .requires(source -> !CobblemonMegas.getInstance().isDisabled())
+                .requires(source ->
+                        !CobblemonMegas.getInstance().isDisabled() &&
+                                CobblemonMegas.getInstance().getPermissionValidator().hasPermission(source, MIGRATE_STONE))
                 .executes(new MigrateMegaStone()));
     }
 

--- a/common/src/main/java/com/selfdot/cobblemonmegas/common/command/MigrateMegaStone.java
+++ b/common/src/main/java/com/selfdot/cobblemonmegas/common/command/MigrateMegaStone.java
@@ -16,6 +16,8 @@ public class MigrateMegaStone implements Command<ServerCommandSource> {
         var player = context.getSource().getPlayerOrThrow();
 
         var handStack = player.getMainHandStack();
+        // You would think an empty hand would not retain NBT from the last held item, right? WRONG!
+        if (handStack.isEmpty()) return error(player, "Hand does not contain valid or old mega stone");
         if (handStack.getNbt() == null) return error(player, "Hand does not contain valid or old mega stone");
         if (!handStack.getOrCreateNbt().contains("ShowdownID")) return error(player, "Hand does not contain valid or old mega stone");
         var showdownId = handStack.getOrCreateNbt().getString("ShowdownID");

--- a/common/src/main/java/com/selfdot/cobblemonmegas/common/command/permissions/MegasPermissions.java
+++ b/common/src/main/java/com/selfdot/cobblemonmegas/common/command/permissions/MegasPermissions.java
@@ -23,9 +23,12 @@ public class MegasPermissions {
     public static final Permission GIVE_KEY_STONE = new Permission(
         MEGAS + "givekeystone", CHEAT_COMMANDS_AND_COMMAND_BLOCKS
     );
+    public static final Permission MIGRATE_STONE = new Permission(
+            MEGAS + "migratestone", CHEAT_COMMANDS_AND_COMMAND_BLOCKS
+    );
 
     public static List<Permission> all() {
-        return List.of(RELOAD, MEGA_EVOLVE, MEGA_EVOLVE_SLOT, GET_MEGA_STONE, GIVE_MEGA_STONE, GIVE_KEY_STONE);
+        return List.of(RELOAD, MEGA_EVOLVE, MEGA_EVOLVE_SLOT, GET_MEGA_STONE, GIVE_MEGA_STONE, GIVE_KEY_STONE, MIGRATE_STONE);
     }
 
 }


### PR DESCRIPTION
A duplication issue came up with the migration command added in the prior pull request, this solves that. 
Also added a permission node since it would have been nice to have in this scenario!